### PR TITLE
fix bootstrapping with relative paths + variable typo fix

### DIFF
--- a/PhpSlim/runPhpSlim.php
+++ b/PhpSlim/runPhpSlim.php
@@ -15,14 +15,14 @@ class __PhpSlimBootStrap
             die('The -b option must be followed by a filename '
                 . "and preceed include path and port number.\n");
         }
-        $boostrapFile = $args[$key + 1];
-        if (!is_readable($boostrapFile)) {
+        $bootstrapFile = realpath($args[$key + 1]);
+        if (!is_readable($bootstrapFile)) {
             $message = sprintf(
                 "The specified bootstrap file %s is not readable.\n",
-                $boostrapFile
+                $bootstrapFile
             );
             die($message);
         }
-        include $boostrapFile;
+        include $bootstrapFile;
     }
 }


### PR DESCRIPTION
 is_readable() has problems with relative paths (at least didn't work for me and this fixed it)