### PR TITLE
Start using namespaces to resolve class names

### DIFF
--- a/PhpSlim/PhpSlim/StatementExecutor.php
+++ b/PhpSlim/PhpSlim/StatementExecutor.php
@@ -328,7 +328,7 @@ class PhpSlim_StatementExecutor
     {
         $parts = preg_split('/\.|\:\:|\_/', $className);
         $converted = array_map('ucfirst', $parts);
-        return implode('_', $converted);
+        return implode('\\', $converted);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "ggramlich/PHPSlim",
+  "description": "PHP Slim port for Fitnesse",
+  "keywords": ["PHP", "slim", "tests", "fitnesse"],
+  "license": "",
+  "authors": [
+    {
+      "name": "Gregor Gramlich",
+      "email": "gramlich@eosc.de"
+    }
+  ],
+  "require": {
+    "php": ">=5.3.0"
+  }
+}


### PR DESCRIPTION
This change will make classes using underline to resolve path not to work. But using namespaces is the current standard for PHP anyway...